### PR TITLE
removed WidgetsFlutterBinding.ensureInitialized()

### DIFF
--- a/lib/mobile_scanner_web_plugin.dart
+++ b/lib/mobile_scanner_web_plugin.dart
@@ -24,7 +24,6 @@ class MobileScannerWebPlugin {
       registrar,
     );
     final MobileScannerWebPlugin instance = MobileScannerWebPlugin();
-    WidgetsFlutterBinding.ensureInitialized();
 
     channel.setMethodCallHandler(instance.handleMethodCall);
     event.setController(instance.controller);


### PR DESCRIPTION
- This blocks error reporting via runZonedGuarded
- Also this is should be called before calling runApp method via main method